### PR TITLE
Update rendered-count _after_ async results have displayed

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
+          rendered += suggestions.length;
 
           that.async && that.trigger('asyncReceived', query);
         }

--- a/test/typeahead/dataset_spec.js
+++ b/test/typeahead/dataset_spec.js
@@ -366,6 +366,18 @@ describe('Dataset', function() {
       });
     });
 
+    it('should render all async suggestions if sync had no content', function() {
+      this.source.andCallFake(fakeGetWithEmptySyncAndAsyncSuggestions);
+      this.dataset.update('woah');
+
+      waits(100);
+
+      runs(function() {
+        var rendered = this.dataset.$el.find('.tt-suggestion');
+        expect(rendered).toHaveLength(5);
+      });
+    });
+
     it('should trigger rendered after suggestions are rendered', function() {
       var spy;
 
@@ -466,4 +478,19 @@ describe('Dataset', function() {
       ]);
     }, 0);
   }
+
+  function fakeGetWithEmptySyncAndAsyncSuggestions(query, sync, async) {
+    sync([]);
+
+    setTimeout(function() {
+      async([
+        { value: 'four', raw: { value: 'four' } },
+        { value: 'five', raw: { value: 'five' } },
+        { value: 'six', raw: { value: 'six' } },
+        { value: 'seven', raw: { value: 'seven' } },
+        { value: 'eight', raw: { value: 'eight' } },
+      ]);
+    }, 0);
+  }
+
 });


### PR DESCRIPTION
This ensures that all async results are rendered.